### PR TITLE
Prepare ALDEx3 For Mixed Effects Modeling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ALDEx3
 Title: Linear Models for Sequence Count Data 
-Version: 0.1.1
+Version: 0.2.0
 Authors@R:
     c(person("Justin", "Silverman", email = "JustinSilverman@psu.edu", role = c("aut", "cre")),
       person("Greg", "Gloor", email = "ggloor@uwo.ca", role = c("aut")),

--- a/R/aldex.sampler.R
+++ b/R/aldex.sampler.R
@@ -1,0 +1,103 @@
+##' Get chunks of estimates of the absolute abundances, composition, and scale
+##' given a scale model (internal only).
+##'
+##' @param Y an (D x N) matrix of sequence count, N is number of samples, D
+##'   is number of taxa or genes
+##' @param X A model matrix of dimension P x N (P is number of linear model
+##'   covariates).
+##' @param chunk.size The number of monte carlo samples of the absolute
+##'   abudnances, composition, and scale to return.
+##' @param scale the scale model, can be a function or an N x nsample matrix.
+##' @param scale.args A list of parameters to pass to the scale model
+##' @param return.pars Can include logWperp and logWpara to return the scale
+##'   and composition samples, respetively
+##' @return A list with the absolute abundance estimates logW, and optionally
+##'   also logWperp and logWpara (see return.pars)
+##' @author Justin Silverman, Kyle McGovern
+aldex.chunk <- function(Y, X, chunk.size, scale,
+                        scale.args, return.pars) {
+  N <- ncol(Y)
+  D <- nrow(Y)
+
+  ## dirichlet sample
+  logWpara <- array(NA, c(D, N, chunk.size))
+  for (i in 1:N) {
+    logWpara[,i,] <- log2(rDirichlet(chunk.size, Y[,i]+0.5))
+  }
+
+  ## sample from scale model
+  if (is.null(scale)){
+    stop("You probably want a scale model :)")
+  } else if (is.matrix(scale)) {
+    stopifnot(dim(scale)==c(N, chunk.size))
+    logWperp <- scale
+  } else if (is.function(scale)) {
+    req.args <- formalArgs(scale)
+    scale.args <- scale.args[intersect(names(scale.args), req.args)]
+    if ("logWpara" %in% req.args) scale.args$logWpara <- logWpara
+    if ("X" %in% req.args) scale.args$X <- X
+    if ("Y" %in% req.args) scale.args$Y <- Y
+    logWperp <- do.call(scale, scale.args)
+    ## some error checking to make sure whats returned has right dimensions
+  }
+
+  ## compute scaled abundances (W)
+  logW <- sweep(logWpara, c(2,3), logWperp, FUN=`+`)
+
+  ## memory management
+  if (!("logWperp" %in% return.pars)) rm(logWperp)
+  if (!("logWpara" %in% return.pars)) rm(logWpara)
+
+  ## Return Results
+  out <- list()
+  out$logW <- logW
+  if ("logWperp" %in% return.pars) {
+    out$logWperp <- logWperp
+  }
+  if ("logWpara" %in% return.pars) {
+    out$logWpara <- logWpara
+  }
+  return(out)
+}
+
+##' Get chunks of estimates of the absolute abundances, composition, and scale
+##' given a scale model (internal only).
+##'
+##' @param Y an (D x N) matrix of sequence count, N is number of samples, D
+##'   is number of taxa or genes
+##' @param X A model matrix of dimension P x N (P is number of linear model
+##'   covariates).
+##' @param nsample The total number of monte carlo samples to draw for aldex
+##'   analysis.
+##' @param streamsize memory footprint (approximate) at which to
+##'   use streaming.
+##' @return A vector of values to use as the chunk.size in aldex.chunk
+##' @author Justin Silverman, Kyle McGovern
+aldex.getchunksizes <- function(Y, X, nsample, streamsize) {
+  N <- ncol(Y)
+  D <- nrow(Y)
+
+  ## calculate streaming threshold
+  stream <- FALSE
+  if (N*D*nsample*8/100000 > streamsize) stream <- TRUE
+
+  nsample.remaining <- nsample
+  iter <- 1
+  if (stream) {
+    nsample.local <- floor(streamsize*100000/(N*D*8))
+    if (nsample.local < 1) stop("streamsize too small")
+  } else {
+    nsample.local <- nsample
+  }
+
+  chunk_sizes <- c()
+  while (nsample.remaining > 0) {
+    if(nsample.remaining<nsample.local) {
+      chunk_sizes <- c(chunk_sizes, nsample.remaining)
+    } else {
+      chunk_sizes <- c(chunk_sizes, nsample.local)
+    }
+    nsample.remaining <- nsample.remaining - nsample.local
+  }
+  return(chunk_sizes)
+}

--- a/R/pvals.R
+++ b/R/pvals.R
@@ -1,0 +1,47 @@
+##' Calculate p-values adjusting for changes in sign as described by Nixon
+##' et al. (2024) in Beyond Normalization: Incorporating Scale Uncertainty
+##' in Microbiome and Gene Expression Analysis (internal only)
+##'
+##' @param p.lower A P x D x S matrix for P covariates, D taxa/genes, and S
+##'   monte carlo samples representing the lower tail p.values
+##' @param p.lower A P x D x S matrix for P covariates, D taxa/genes, and S
+##'   monte carlo samples representing the upper tail p.values
+##' @param p.adjust.method An adjutment method for p.adjust
+##' @return A list with P x D matrices with the non-adjusted and adjusted
+##'   p-values.
+##' @author Justin Silverman, Kyle McGovern
+aldex.pvals <- function(p.lower, p.upper, p.adjust.method) {
+
+  p.lower <- array(pmin(1, 2 * p.lower), dim = dim(p.lower))
+  p.upper <- array(pmin(1, 2 * p.upper), dim = dim(p.upper))
+
+  p.lower.adj <- apply(p.lower, c(1,3), function(item) {
+    p.adjust(item, method=p.adjust.method)
+  })
+  p.upper.adj <- apply(p.upper, c(1,3), function(item) {
+    p.adjust(item, method=p.adjust.method)
+  })
+
+  p.lower.mean <- apply(p.lower, c(2,1), mean)
+  p.upper.mean <- apply(p.upper, c(2,1), mean)
+  rm(p.lower, p.upper)
+
+  p.res <- c()
+  for(col_i in 1:ncol(p.lower.mean)) {
+    tmp_mat <- cbind(p.lower.mean[,col_i],
+                     p.upper.mean[,col_i])
+    p.res <- rbind(p.res, apply(tmp_mat, 1, min))
+  }
+  rm(p.lower.mean, p.upper.mean)
+
+  p.lower.mean.adj <- apply(p.lower.adj, c(1,2), mean)
+  p.upper.mean.adj <- apply(p.upper.adj, c(1,2), mean)
+  p.adj.res <- c()
+  for(col_i in 1:ncol(p.lower.mean.adj)) {
+    tmp_mat <- cbind(p.lower.mean.adj[,col_i],
+                     p.upper.mean.adj[,col_i])
+    p.adj.res <- rbind(p.adj.res, apply(tmp_mat, 1, min))
+  }
+  rm(p.lower.mean.adj, p.upper.mean.adj)
+  return(list(p.res=p.res, p.adj.res=p.adj.res))
+}

--- a/R/scale.R
+++ b/R/scale.R
@@ -18,6 +18,6 @@ clr <- function(X, logWpara, gamma=0.5) {
 
   tmp <- P*nsample
   Lambdaperp <- matrix(rnorm(tmp,0,gamma), P, nsample)
-  logWperp <- logWperp + t(X)%*% Lambdaperp
+  logWperp <- logWperp + t(X)%*%Lambdaperp
   return(logWperp)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,14 +5,18 @@
 ##' combines those arrays along the third dimension.
 ##' @param l a list, where every element is itself a list of 3D arrays.
 ##' @return a list of 3D arrays
-##' @author Justin Silverman
-##' @import purrr
-combine.streams <- function(l) {
-   l <- purrr::list_transpose(l)
-   n <- length(l)
-   for (i in 1:n) {
-     l[[i]] <- abind::abind(l[[i]], along=3)
-   }
-   return(l)
- }
+##' @author Justin Silverman, Kyle McGovern
+combine.streams <- function(out) {
+  out.names <- names(out[[1]])
+  out <- lapply(out.names, function(name) {
+    ## TODO this is a bit hacky
+    if(length(dim(out[[1]][[name]]))>2) {
+      do.call(abind::abind, c(lapply(out, function(x) x[[name]]), list(along = 3)))
+    } else {
+      do.call(cbind, c(lapply(out, function(x) x[[name]])))
+    }
 
+  })
+  names(out) <- out.names
+  out
+}


### PR DESCRIPTION
This PR is a fairly large update. I have removed the scale sampling, multinomial dirichlet, streaming, and pvalue calculation from the `aldex` function and made them functions for general usage. By doing so I have removed a lot of logic from within the `aldex` function, cleaning it up. I have even been able to remove the `aldex.lm.internal` function entirely.

Thoughts:

I don't think mixed effects modeling should be integrated into the `aldex` function. Imagine in the future we want to add 5 different models. We risk overloading the user with 1000 options in `aldex`. This update seperates the functionality making it easier to define a separate function for mixed effects modeling. I suggest the following functions:

- remove `aldex`, replace with `aldex.lm`: three required arguments: Y, formula, data (mimicking the standard lm function). Remove the X argument.
- `aldex.simple`: recapitulates the exact results of ALDEx2 when using the simple welch.test with binary covariate(s)
- `aldex.mem`: mixed effects modeling. Right now in the `aldex` function, X can be a formula. But I need to be able to pass in two formulas for fixed and random effects for the `nlme` method. Easier to just define my own function.

TODO: I had to fix the `combine.streams` function, it feels hacky right now, we might want to code how to combine the results for each individual variable. 

I have also fixed a bug:

- In the existing version, if the stream monte carlo sample size is say 25 and nsample is 224 it will only return 200 samples.